### PR TITLE
Bug fix: Ignore rays ending at image boundary

### DIFF
--- a/swt.py
+++ b/swt.py
@@ -90,6 +90,9 @@ class SWTScrubber(object):
 
                         if cur_x != prev_x or cur_y != prev_y:
                             # we have moved to the next pixel!
+                            if cur_x < 0 or cur_y < 0:
+                                # out of image boundary
+                                break
                             try:
                                 if edges[cur_y, cur_x] > 0:
                                     # found edge,


### PR DESCRIPTION
Indexing the `ndarray` `edges` with a negative index won't throw an IndexError and therefore a ray ending at the boundary of the image is not ingored.